### PR TITLE
Import java.util.List when using nullable helpers

### DIFF
--- a/internal/codegen/common.go
+++ b/internal/codegen/common.go
@@ -42,7 +42,8 @@ type nullableHelper struct {
 	ArgType      string
 }
 
-func (b *IndentStringBuilder) writeNullableHelpers(nullableHelpers core.NullableHelpers, nonNullAnnotation, nullableAnnotation string) {
+func (b *IndentStringBuilder) writeNullableHelpers(nullableHelpers core.NullableHelpers, nonNullAnnotation, nullableAnnotation string) []string {
+	imports := make([]string, 0)
 	methodTypes := []nullableHelper{
 		{nullableHelpers.Int, "Integer", "Int"},
 		{nullableHelpers.Long, "Long", "Long"},
@@ -77,7 +78,11 @@ func (b *IndentStringBuilder) writeNullableHelpers(nullableHelpers core.Nullable
 		))
 		b.WriteIndentedString(2, "var colVal = rs.getArray(col); return colVal == null ? null : Arrays.asList(as.cast(colVal.getArray()));\n")
 		b.WriteIndentedString(1, "}\n")
+
+		imports = append(imports, "java.util.List")
 	}
+
+	return imports
 }
 
 func (b *IndentStringBuilder) writeParameter(javaType core.JavaType, name, nonNullAnnotation, nullableAnnotation string) ([]string, error) {

--- a/internal/codegen/queries.go
+++ b/internal/codegen/queries.go
@@ -162,7 +162,9 @@ func BuildQueriesFile(engine string, config core.Config, queryFilename string, q
 
 	// boilerplate methods to allow for getting null primitive values
 	body.WriteString("\n")
-	body.writeNullableHelpers(nullableHelpers, nonNullAnnotation, nullableAnnotation)
+
+	imp := body.writeNullableHelpers(nullableHelpers, nonNullAnnotation, nullableAnnotation)
+	imports = append(imports, imp...)
 
 	for _, q := range queries {
 		body.WriteString("\n")


### PR DESCRIPTION
Hello!

I came across an issue where `java.util.List` is not imported for `private static <T> @Nullable List<T> getList(@NonNull ResultSet rs, int col, Class<T[]> as) throws SQLException {`

This may have been missed during testing as the import is provided when queries return multiple results, as I discovered this on a query that had nullable values, but not multiple results.

I did think about adding this to https://github.com/tandemdude/sqlc-gen-java/blob/master/internal/codegen/queries.go#L129, as `java.util.Arrays` is imported there, but I wasn't sure as it could result in unused imports. If you'd prefer it there, let me know.