### PR TITLE
Feature/query parameter limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A WASM plugin for SQLC allowing the generation of Java code.
 | `package`                        | string   | yes      | The name of the package where the generated files will be located.                                                                        |
 | `emit_exact_table_names`         | boolean  | no       | Whether table names will not be forced to singular form when generating the models. Defaults to `false`.                                  |
 | `inflection_exclude_table_names` | []string | no       | Table names to be excluded from being forced into singular form when generating the models.                                               |
-| `query_parameter_limit`          | integer  | no       | not yet implemented                                                                                                                       |
+| `query_parameter_limit`          | integer  | no       |  The max number of query parameters allowed before automatically generating a data model for method input.                                                                                                                      |
 | `indent_char`                    | string   | no       | The character to use to indent the code. Defaults to space `" "`.                                                                         |
 | `chars_per_indent_level`         | integer  | no       | The number of characters per indent level. Defaults to `4`.                                                                               |
 | `nullable_annotation`            | string   | no       | The full import path for the nullable annotation to use. Defaults to `org.jspecify.annotations.Nullable`. Set to empty string to disable. |

--- a/internal/codegen/queries.go
+++ b/internal/codegen/queries.go
@@ -254,7 +254,7 @@ func BuildQueriesFile(engine string, config core.Config, queryFilename string, q
 		queryInput := ""
 
 		// input method for query params limit
-		if len(q.Args) > config.QueryParameterLimit {
+		if len(q.Args) > config.QueryParameterLimit && config.QueryParameterLimit != 0 {
 			queryInput = queryInputName(q)
 
 			body.WriteString("\n")
@@ -279,7 +279,7 @@ func BuildQueriesFile(engine string, config core.Config, queryFilename string, q
 		// write the method signature
 		body.WriteString("\n")
 		body.WriteIndentedString(1, fmt.Sprintf("public %s %s(", returnType, q.MethodName))
-		if len(q.Args) > config.QueryParameterLimit {
+		if len(q.Args) > config.QueryParameterLimit && config.QueryParameterLimit != 0 {
 			body.WriteString(fmt.Sprintf("%s %sinput) throws SQLException{\n", queryInput, queryInput))
 		} else if len(q.Args) > 0 {
 			body.WriteString("\n")

--- a/internal/codegen/queries.go
+++ b/internal/codegen/queries.go
@@ -253,8 +253,9 @@ func BuildQueriesFile(engine string, config core.Config, queryFilename string, q
 
 		queryInput := ""
 
+		useInputRecord := config.QueryParameterLimit != 0 && len(q.Args) >= config.QueryParameterLimit
 		// input method for query params limit
-		if len(q.Args) > config.QueryParameterLimit && config.QueryParameterLimit != 0 {
+		if useInputRecord {
 			queryInput = queryInputName(q)
 
 			body.WriteString("\n")
@@ -279,22 +280,29 @@ func BuildQueriesFile(engine string, config core.Config, queryFilename string, q
 		// write the method signature
 		body.WriteString("\n")
 		body.WriteIndentedString(1, fmt.Sprintf("public %s %s(", returnType, q.MethodName))
-		if len(q.Args) > config.QueryParameterLimit && config.QueryParameterLimit != 0 {
-			body.WriteString(fmt.Sprintf("%s %sinput) throws SQLException{\n", queryInput, queryInput))
-		} else if len(q.Args) > 0 {
+
+		if len(q.Args) > 0 {
 			body.WriteString("\n")
 
-			for i, arg := range q.Args {
-				imps, err := body.writeParameter(arg.JavaType, arg.Name, nonNullAnnotation, nullableAnnotation)
-				if err != nil {
-					return "", nil, err
-				}
-				if imps != nil {
-					imports = append(imports, imps...)
-				}
+			if useInputRecord {
+				body.WriteIndentedString(2, fmt.Sprintf("%s input", queryInput))
+			}
 
-				if i != len(q.Args)-1 {
-					body.WriteString(",\n")
+			for i, arg := range q.Args {
+				if useInputRecord {
+					arg.Name = "input." + arg.Name
+				} else {
+					imps, err := body.writeParameter(arg.JavaType, arg.Name, nonNullAnnotation, nullableAnnotation)
+					if err != nil {
+						return "", nil, err
+					}
+					if imps != nil {
+						imports = append(imports, imps...)
+					}
+
+					if i != len(q.Args)-1 {
+						body.WriteString(",\n")
+					}
 				}
 
 				methodBody.WriteIndentedString(2, arg.BindStmt(engine)+"\n")


### PR DESCRIPTION
## Add support for query_parameter_limit configuration option

This PR implements support for the query_parameter_limit configuration option, which enables automatic generation of a data model as method input when the number of query parameters exceeds the specified limit.